### PR TITLE
fix(backend): stop heartbeat status updates for ScheduledWorkflows. Fixes #8757

### DIFF
--- a/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
@@ -271,7 +271,10 @@ func (s *ScheduledWorkflow) UpdateStatus(updatedEpoch int64, submitted bool,
 	scheduledEpoch int64, active []swfapi.WorkflowStatus,
 	completed []swfapi.WorkflowStatus, location *time.Location) {
 
-	updatedTime := metav1.NewTime(time.Unix(updatedEpoch, 0).UTC())
+	// updatedEpoch contains current time but using current time causes the
+	// SWF to fail to be reconciled by the controller. Set LastProbeTime and
+	// LastTransitionTime to 0 to avoid the irreconcilable status updates.
+	updatedTime := metav1.NewTime(time.Unix(0, 0).UTC())
 
 	conditionType, status, message := s.getStatusAndMessage(len(active))
 


### PR DESCRIPTION
**Description of your changes:**

Closes issue: https://github.com/kubeflow/pipelines/issues/8757

Every time the ScheduledWorkflow controller syncs a SWF resource, it updates the Last Heartbeat Time and Last Transition Time to the current time in the status block.

```
Status:
  Conditions:
    Last Heartbeat Time:   2024-11-07T11:16:33Z
    Last Transition Time:  2024-11-07T11:16:33Z
    Message:               The schedule is disabled.
    Reason:                Disabled
    Status:                True
    Type:                  Disabled
```

These heartbeat updates result in an infinite reconciliation loop:
- SWF is added to controller work queue.
- Controller processes the SWF and updates the status' LastProbeTime and LastTransitionTime to current time.
- Object is re-written to ETCD and the resourceVersion is updated.
- Shared informer detects that the resourceVersion has changed.
- Controller event handler re-adds the SWF to the work queue.
- This reconciliation loop occurs every 10 seconds for every SWF resource on the cluster. The reason it's 10s and not 1s is because the controller has a default queue backoff of 10s, so events are always queued for a minimum of 10s.

**ETCD performance before & after**

I measured ETCD bytes written for all resources on our cluster over a 10 minute time span. Once this fix was instituted, we saw a dramatic decrease in ETCD usage.

![etcd](https://github.com/user-attachments/assets/4b2733d1-6f8f-4910-9296-f51d5dae0fec)

The chart agrees with the back-of-the-napkin math:
- The average size of our SWF objects is 270kb.
- Controller re-writes the object every 10 seconds (6x/min).
- Bytes written to ETCD per minute = 270kb x 6/min = 1.6MB/minute per SWF.
- Our cluster had 54 SWFs at the time of the analysis.
- ETCD write throughput is 54*1.6mb/min = 86mb/min = 430MB every 5 min.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
